### PR TITLE
Куча твиков для уменьшения частоты появления антагонистов/Баланс

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -499,7 +499,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 8
+    weight: 4 # Reserve edit, 2x times less
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -176,13 +176,13 @@
   id: Traitor
   components:
   - type: GameRule
-    minPlayers: 5
+    minPlayers: 9 # Reserve edit, min 9 playes for traitors 
   - type: AntagSelection
     selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ Traitor ]
-      max: 8
-      playerRatio: 10
+      max: 2 # Reserve edit, max 2 traitors per round
+      playerRatio: 10 # Reserve edit, 10 crews to 1 traitor
       blacklist:
         components:
         - AntagImmune

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -182,7 +182,7 @@
     definitions:
     - prefRoles: [ Traitor ]
       max: 2 # Reserve edit, max 2 traitors per round
-      playerRatio: 10 # Reserve edit, 10 crews to 1 traitor
+      playerRatio: 12 # Reserve edit, 12 crews to 1 traitor
       blacklist:
         components:
         - AntagImmune

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -96,7 +96,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 30
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml # goob edit
   - type: AntagSelection

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -181,7 +181,7 @@
     selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ Traitor ]
-      max: 2 # Reserve edit, max 2 traitors per round
+      max: 8
       playerRatio: 12 # Reserve edit, 12 crews to 1 traitor
       blacklist:
         components:

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -180,7 +180,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
-    weight: 15
+    weight: 5 # Reserve edit, 3x times less
     duration: 1
     earliestStart: 50
     minimumPlayers: 20

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -4,8 +4,8 @@
   components:
   - type: StationEvent
     earliestStart: 15
-    weight: 7.5
-    minimumPlayers: 10
+    weight: 3.75 # Reserve edit, 2x times less
+    minimumPlayers: 15 # Reserve edit, need 1.5x more players
     duration: 1
   - type: RuleGrids
   - type: LoadMapRule

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -7,7 +7,7 @@
     Extended: 0.15 # Reserve edit, calm rounds are real
     Traitorling: 0.04 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.09
-    # Honkops: 0.01 # Reserve edit, no honkops
+    Honkops: 0.01
     NukeTraitor: 0.01
     NukeLing: 0.01
     Revolutionary: 0.05 # Maybe 0.04 after wiz/cult?

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,11 +2,12 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.47
-    Changeling: 0.14
+    Traitor: 0.35
+    Changeling: 0.12
+    Extended: 0.15 # Reserve edit, calm rounds are real
     Traitorling: 0.04 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.09
-    Honkops: 0.01
+    # Honkops: 0.01 # Reserve edit, no honkops
     NukeTraitor: 0.01
     NukeLing: 0.01
     Revolutionary: 0.05 # Maybe 0.04 after wiz/cult?


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Был в шоке когда понял что у губов вообще нету калмраундов (Extended режима не было в секрете), вырезал хонкопов с секрета и уменьшил кучу констант. Грызите и предлагайте что нужно перебалансить

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] Я написал апдейт лог к этому пулл реквесту основываясь на примере [EXAMPLE_RELEASE_NOTES.md](EXAMPLE_RELEASE_NOTES.md).
- [x] Я знаю, как выглядит заполненный чекбокс
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

:cl: Sodka

## Спокойствие, умиротворение, гармония

- tweak: Изменена частота появления спящих агентов в два раза: 8 => 4
- tweak: Изменена частота появления блоба в три раза: 15 => 5
- tweak: Изменен шанс появления абдукторов в два раза: 7.35 => 3.75
- tweak: Изменено минимальное кол-во игроков для запуска предателей: 5 => 9
- tweak: Изменено минимальное кол-во игроков для появления абдуктора: 10 => 15
- tweak: Изменено кол-во предателей за раунд: 8 => 2
- tweak: Изменен баланс на кол-во предателей к членам экипажа: 10 => 12
- add: Добавлена возможность появления расширенного (спокойного) режима в секрете
- remove: Хонкоперы удалены из секрета