### PR TITLE
NOBODY LOVES BARRATRY

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -69,7 +69,7 @@ namespace Content.IntegrationTests.Tests
             "FlandHighPop", // Goobstation - add highpop maps
             "OriginHighPop",
             "OasisHighPop",
-            "Barratry", // Goobstation - add Barratry
+            //"Barratry", // Goobstation - add Barratry (NOBODY LOVES BARRATRY)
             "Kettle", // Goobstation - add Kettle
             "Submarine", // Goobstation - add Submarine
             "Lambda", // Goobstation - add Lambda

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -21,7 +21,8 @@
 # - Train # Goobstation - all my friends hate train
   - FlandHighPop
   - OasisHighPop
-  - Barratry # Goobstation - Re-add barratry
+  # NOBODY LOVES BARRATRY
+  #- Barratry # Goobstation - Re-add barratry
   - Kettle # Goobstation - Re-add kettle (before it was gemini!)
   - Submarine # goobstation - kill yourse
   - Lambda # Goobstation - literally someone forgot to add it???


### PR DESCRIPTION
## Описание PR
Карта `Barratry` была удалена из обычного мап пула.

## Почему / Баланс
Карта `Barratry` - самая ненавистная карта. Если она попадается, то все игроки или просят перезапуск раунда, или прыгают в СМ (при этом, одно не мешает другому). Из этого исходит вопрос - а нужна ли вообще такая карта? Совственно, по этой причине я и сделал этот ПР.

Данный ПР - это социальный опыт. Если станция востребована, то игроки будут просить вернуть её. Ежели никто и вправду никто её не любит - всем будет только в радость.

### Обновление

:cl: Quartug
- remove: Карта Barratry больше не может появиться как станция при обычных условиях.
