### PR TITLE
Удаление сервера мониторинга экипажа с лаваленда

### DIFF
--- a/Resources/Maps/_Lavaland/Lavaland/outpost_lavaland.yml
+++ b/Resources/Maps/_Lavaland/Lavaland/outpost_lavaland.yml
@@ -4338,13 +4338,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 9.5,-0.5
       parent: 2
-- proto: ComputerCrewMonitoring
-  entities:
-  - uid: 1239
-    components:
-    - type: Transform
-      pos: 7.5,9.5
-      parent: 2
 - proto: ComputerId
   entities:
   - uid: 1242
@@ -4458,13 +4451,6 @@ entities:
     components:
     - type: Transform
       pos: 9.5,12.5
-      parent: 2
-- proto: CrewMonitoringServer
-  entities:
-  - uid: 1269
-    components:
-    - type: Transform
-      pos: 11.5,16.5
       parent: 2
 - proto: DisposalBend
   entities:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Удаляет сервер мониторинга экипажа с оутпоста лаваленда, ибо он мешает серверу на станции (по какой-то причине)

Также удаляет консоль мониторинга экипажа с оутпоста, ведь без сервера она бесполезна

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] Я написал апдейт лог к этому пулл реквесту основываясь на примере [EXAMPLE_RELEASE_NOTES.md](EXAMPLE_RELEASE_NOTES.md).
- [x] Я знаю, как выглядит заполненный чекбокс
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

:cl: CSQRB

## Название апдейта

### Багфиксы

- fix: Удалён сервер мониторинга экипажа с лаваленда, так-как он мешает работе серверу на станции
