### PR TITLE
Removed changelings and thieves on NukeOps

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -256,7 +256,7 @@
   showInVote: false
   rules:
     - Nukeops
-    - SubGamemodesRule
+  #  - SubGamemodesRule #Reserve edit - no thieves on nukeops
     - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -44,14 +44,14 @@
     Nukeops: 0.09
     Honkops: 0.01
     NukeTraitor: 0.01
-    NukeLing: 0.06
-    Revolutionary: 0.04
+    # NukeLing: 0.06 #Reserve edit
+    Revolutionary: 0.06 #Reserve edit
     RevTraitor: 0.04
     RevLing: 0.03
     Zombie: 0.13
     # Survival: 0.03
-    Blob: 0.04
-    Wizard: 0.05 # TEMP INCREASE FROM 10
+    Blob: 0.06 #Reserve edit
+    Wizard: 0.07 # TEMP INCREASE FROM 10 #Reserve edit
   #  KesslerSyndrome: 0.01 # Goobstation - remove kessler
   # Cult: 0.05
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Убран режим ЛингОпс, на режиме нюкопс вырезаны воры.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Трекер: https://discord.com/channels/1291325264227471410/1359471214543896667
## Technical details
<!-- Summary of code changes for easier review. -->
Твикнуты веса в пуле секрета, убран SubGamemodesRule в режиме нюки, он отвечает исключтельно за воров на данный момент.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

:cl: Svarshik
- remove: Убраны генокрады и воры из режима ЯО
